### PR TITLE
Fix handling of focus charges

### DIFF
--- a/src/sim.rs
+++ b/src/sim.rs
@@ -148,9 +148,6 @@ impl Sim {
             }
             if self.banner.focus_charges {
                 focus_charges = (focus_charges + nonfocus_count).min(3);
-                if got_focus {
-                    focus_charges = 0;
-                }
             }
             orb_count += Sim::orb_cost(chosen_count);
             if self.goal_data.is_met() {


### PR DESCRIPTION
Under current behavior, the Focus Charge lights go out if an off focus 5 Star Hero is pulled before all 3 Focus Charge lights have lit up. This behavior is incorrect.

The correct behavior is described in the Focus Charge documentation:
https://new-guide.fire-emblem-heroes.com/en-US/feh-3760.html

"The charges will automatically reset if you summon a 5[*] focus Hero while all three charges are active"

The key point is all 3 charges must be lit before they will reset.

This commit changes the behavior of the simulator to match the documentation which is the same as the in game behavior. Focus Charges will not reset if a 5* Hero is pulled before all 3 charges are lit.