### PR TITLE
Add 4* Special Rate to Sim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub enum Pool {
     Focus,
     Fivestar,
     FourstarFocus,
+    FourstarSpecial,
     Fourstar,
     Threestar,
 }
@@ -82,8 +83,9 @@ impl TryFrom<u8> for Pool {
             0 => Focus,
             1 => Fivestar,
             2 => FourstarFocus,
-            3 => Fourstar,
-            4 => Threestar,
+            3 => FourstarSpecial,
+            4 => Fourstar,
+            5 => Threestar,
             _ => return Err(()),
         })
     }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -92,8 +92,8 @@ impl Sim {
             self.tables.pool_sizes[2][color as usize] = 1;
         }
 
-        for color in 0..6 {
-            self.tables.color_dists[color] = WeightedIndex4::new(self.tables.pool_sizes[color]);
+        for pool in 0..6 {
+            self.tables.color_dists[pool] = WeightedIndex4::new(self.tables.pool_sizes[pool]);
         }
 
         for pity_incr in 0..26 {
@@ -273,10 +273,10 @@ impl Sim {
 
         let lower_dem = bases[Pool::FourstarFocus as usize] + bases[Pool::FourstarSpecial as usize]
                         + bases[Pool::Fourstar as usize] + bases[Pool::Threestar as usize];
-        probabilities[Pool::FourstarFocus as usize] -= pity_pct * bases[Pool::FourstarFocus as usize] / lower_dem / 100.0;
-        probabilities[Pool::FourstarSpecial as usize] -= pity_pct * bases[Pool::FourstarSpecial as usize] / lower_dem / 100.0;
-        probabilities[Pool::Fourstar as usize] -= pity_pct * bases[Pool::Fourstar as usize] / lower_dem / 100.0;
-        probabilities[Pool::Threestar as usize] -= pity_pct * bases[Pool::Threestar as usize] / lower_dem / 100.0;
+        probabilities[Pool::FourstarFocus as usize] -= pity_pct * bases[Pool::FourstarFocus as usize] / lower_dem;
+        probabilities[Pool::FourstarSpecial as usize] -= pity_pct * bases[Pool::FourstarSpecial as usize] / lower_dem;
+        probabilities[Pool::Fourstar as usize] -= pity_pct * bases[Pool::Fourstar as usize] / lower_dem;
+        probabilities[Pool::Threestar as usize] -= pity_pct * bases[Pool::Threestar as usize] / lower_dem;
         probabilities
     }
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -5,7 +5,7 @@ use rand::distributions::Distribution;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-use weighted_choice::{WeightedIndex4, WeightedIndex5};
+use weighted_choice::{WeightedIndex4, WeightedIndex6};
 
 use goal::{CustomGoal, GoalKind};
 
@@ -36,9 +36,9 @@ pub struct Sim {
 /// Precalculated tables for the probabilities of units being randomly chosen.
 #[derive(Debug, Copy, Clone, Default)]
 struct RandTables {
-    pool_sizes: [[u8; 4]; 5],
-    pool_dists: [WeightedIndex5; 26],
-    color_dists: [WeightedIndex4; 5],
+    pool_sizes: [[u8; 4]; 6],
+    pool_dists: [WeightedIndex6; 26],
+    color_dists: [WeightedIndex4; 6],
 }
 
 /// Scratch space for representing the goal in a way that is faster to work with.
@@ -79,8 +79,9 @@ impl Sim {
     fn init_probability_tables(&mut self) {
         self.tables.pool_sizes = [
             [0, 0, 0, 0],
-            [18, 17, 12, 13],
+            [18, 17, 12, 14],
             [0, 0, 0, 0],
+            [81, 63, 53, 44],
             [49, 50, 39, 53],
             [49, 50, 39, 53],
         ];
@@ -91,13 +92,13 @@ impl Sim {
             self.tables.pool_sizes[2][color as usize] = 1;
         }
 
-        for color in 0..5 {
+        for color in 0..6 {
             self.tables.color_dists[color] = WeightedIndex4::new(self.tables.pool_sizes[color]);
         }
 
         for pity_incr in 0..26 {
             self.tables.pool_dists[pity_incr] =
-                WeightedIndex5::new(self.probabilities(pity_incr as u32));
+                WeightedIndex6::new(self.probabilities(pity_incr as u32));
         }
     }
 
@@ -196,6 +197,7 @@ impl Sim {
             || sample.0 == Pool::Fourstar
             || sample.0 == Pool::Fivestar
             || (sample.0 == Pool::FourstarFocus && !self.goal_data.is_fourstar_focus)
+            || sample.0 == Pool::FourstarSpecial
             || !self.goal_data.color_needed[color as usize]
         {
             return PullOrbResult {
@@ -255,7 +257,7 @@ impl Sim {
 
     /// Calculates the actual probabilities of selecting a unit from each of the four
     /// possible pools after a certain number of rate increases.
-    fn probabilities(&self, pity_incr: u32) -> [f32; 5] {
+    fn probabilities(&self, pity_incr: u32) -> [f32; 6] {
         let bases = self.bases();
         let pity_pct = if pity_incr >= 25 {
             100.0 - bases[Pool::Focus as usize] - bases[1]
@@ -269,29 +271,31 @@ impl Sim {
         probabilities[Pool::Focus as usize] += pity_pct * focus_ratio;
         probabilities[Pool::Fivestar as usize] += pity_pct * (1.0 - focus_ratio);
 
-        let lower_ratio = bases[Pool::Fourstar as usize]
-            / (bases[Pool::Fourstar as usize] + bases[Pool::Threestar as usize]);
-        probabilities[Pool::Fourstar as usize] -= pity_pct * lower_ratio;
-        probabilities[Pool::Threestar as usize] -= pity_pct * (1.0 - lower_ratio);
+        let lower_dem = bases[Pool::FourstarFocus as usize] + bases[Pool::FourstarSpecial as usize]
+                        + bases[Pool::Fourstar as usize] + bases[Pool::Threestar as usize];
+        probabilities[Pool::FourstarFocus as usize] -= pity_pct * bases[Pool::FourstarFocus as usize] / lower_dem / 100.0;
+        probabilities[Pool::FourstarSpecial as usize] -= pity_pct * bases[Pool::FourstarSpecial as usize] / lower_dem / 100.0;
+        probabilities[Pool::Fourstar as usize] -= pity_pct * bases[Pool::Fourstar as usize] / lower_dem / 100.0;
+        probabilities[Pool::Threestar as usize] -= pity_pct * bases[Pool::Threestar as usize] / lower_dem / 100.0;
         probabilities
     }
 
     /// Gives the base probabilities of selecting a unit from each pool.
-    fn bases(&self) -> [f32; 5] {
+    fn bases(&self) -> [f32; 6] {
         let (focus, fivestar) = self.banner.starting_rates;
         if self.banner.fourstar_focus.is_some() {
-            [3.0, 3.0, 3.0, 55.0, 36.0]
+            [3.0, 3.0, 3.0, 3.0, 52.0, 36.0]
         } else if (focus, fivestar) == (6, 0) {
             // The lower-rarity breakdown on this new banner is different
             // for no apparent reason
-            [6.0, 0.0, 0.0, 60.0, 34.0]
+            [6.0, 0.0, 0.0, 3.0, 57.0, 34.0]
         } else {
             let focus = focus as f32;
             let fivestar = fivestar as f32;
-            let fivestar_total = focus + fivestar;
-            let fourstar = (100.0 - fivestar_total) * 58.0 / 94.0;
-            let threestar = (100.0 - fivestar_total) * 36.0 / 94.0;
-            [focus, fivestar, 0.0, fourstar, threestar]
+            let fivestar_total = focus + fivestar + 3.0;
+            let fourstar = (100.0 - fivestar_total) * 55.0 / 91.0;
+            let threestar = (100.0 - fivestar_total) * 36.0 / 91.0;
+            [focus, fivestar, 0.0, 3.0, fourstar, threestar]
         }
     }
 }

--- a/src/weighted_choice.rs
+++ b/src/weighted_choice.rs
@@ -43,47 +43,53 @@ impl Distribution<usize> for WeightedIndex4 {
 
 /// Optimized version of rand::WeightedIndex for a fixed-size collection of five floats.
 #[derive(Copy, Clone, Debug, Default)]
-pub struct WeightedIndex5 {
+pub struct WeightedIndex6 {
     // Cumulative weights stored for faster lookup
-    values: [f32; 5],
+    values: [f32; 6],
 }
 
-impl WeightedIndex5 {
+impl WeightedIndex6 {
     /// Constructs a sampler from the given weights. Weights do not need to sum to 1.
-    pub fn new<T: Into<f32> + Copy>(values: [T; 5]) -> Self {
+    pub fn new<T: Into<f32> + Copy>(values: [T; 6]) -> Self {
         let total = values[0].into()
             + values[1].into()
             + values[2].into()
             + values[3].into()
-            + values[4].into();
+            + values[4].into()
+            + values[5].into();
         Self {
             values: [
                 values[0].into() / total,
                 (values[0].into() + values[1].into()) / total,
                 (values[0].into() + values[1].into() + values[2].into()) / total,
                 (values[0].into() + values[1].into() + values[2].into() + values[3].into()) / total,
+                (values[0].into() + values[1].into() + values[2].into() + values[3].into() + values[4].into()) / total,
                 1.0,
             ],
         }
     }
 }
 
-impl Distribution<usize> for WeightedIndex5 {
+impl Distribution<usize> for WeightedIndex6 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
         let choice = rng.gen::<f32>();
-        if choice > self.values[1] {
-            if choice > self.values[2] {
-                if choice > self.values[3] {
-                    4
+        if choice > self.values[2] {
+            if choice > self.values[3] {
+                if choice > self.values[4] {
+                    5
                 } else {
-                    3
+                    4
                 }
             } else {
-                2
+                3
             }
         } else {
             if choice > self.values[0] {
-                1
+                if choice > self.values[1] {
+                    2
+                } else {
+                    1
+                }
             } else {
                 0
             }


### PR DESCRIPTION
This is the first iteration of taking into account the effect
4* Special Rates have on summoning. Right now this assumes the
rate always starts at 3% (which has always been the case so far)
and the pools for 3* and 4* units are the same (which is currently
the case).

This doesn't include 4* Special Hero Special Rates, which would
add another 3* rate to the table. Given that this particular rate
is very rare as opposed to the normal 4* Special Rate (only appears
on old seasonal reruns) and would need some mechanism to turn
it on, I forwent that for now.
